### PR TITLE
Update Regions.js

### DIFF
--- a/web/libs/editor/src/mixins/Regions.js
+++ b/web/libs/editor/src/mixins/Regions.js
@@ -234,7 +234,7 @@ const RegionsMixin = types
           annotation.stopLinkingMode();
           annotation.regionStore.unselectAll();
         } else {
-          self._selectArea(ev?.ctrlKey || ev?.metaKey);
+          self._selectArea(ev?.ctrlKey || ev?.metaKey || ev?.shiftKey);
         }
       },
 


### PR DESCRIPTION
allow shiftkey to activate "additive mode" in the even of onClickRegion


**Describe the bug**
Function for selecting a range of regions (Select first, then Shift+click on last) is not working, as per the docs description in [Labelling Guide > Select multiple regions](https://labelstud.io/guide/labeling.html#Select-multiple-regions)


**To Reproduce**
Steps to reproduce the behavior:
1. Go to a task with regions, or create a few (RectangleLabel in my case)
2. Click on one in Regions list
3. Hold shift and click on last Region of the desired range of regions to select

**Expected behavior**
All regions in the range between first and last (inclusive) are selected

**Screenshots**
If applicable, add screenshots to help explain your problem.
N/A

**Environment (please complete the following information):**
 - OS: Chrome on Windows 11
 - Label Studio Version [e.g.  1.16.0]

**Additional context**
Haven't tested this fix, but noticed shiftKey was not included to activate additive mode, like Ctrl or Meta key are.

<!--

This description MUST be filled out for a PR to receive a review. Its primary purposes are:

 - to enable your reviewer to review your code easily, and
 - to convince your reviewer that your code works as intended.

Some pointers to think about when filling out your PR description:
 - Reason for change: Description of problem and solution
 - Screenshots: All visible changes should include screenshots.
 - Rollout strategy: How will this code be rolled out? Feature flags / env var / other
 - Testing: Description of how this is being verified
 - Risks: Are there any known risks associated with this change, eg to security or performance?
 - Reviewer notes: Any info to help reviewers approve the PR
 - General notes: Any info to help onlookers understand the code, or callouts to significant portions.

You may use AI tools such as Copilot Actions to assist with writing your PR description (see https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot); however, an AI summary isn't enough by itself. You'll need to provide your reviewer with strong evidence that your code works as intended, which requires actually running the code and showing that it works.

-->
